### PR TITLE
Debian based distros m2crypto package is actually called python-m2crypto

### DIFF
--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -76,7 +76,7 @@ Arch:
 Debian:
   pkgs:
   - salt-minion
-  - m2crypto
+  - python-m2crypto
 Gentoo:
   pkgs:
   - app-admin/salt


### PR DESCRIPTION
Debian based distros m2crypto package is actually called python-m2crypto. 

For more info check: http://packages.ubuntu.com/search?keywords=python-m2crypto
