### PR TITLE
Fix empty array get

### DIFF
--- a/salt/minion/cert.sls
+++ b/salt/minion/cert.sls
@@ -69,7 +69,7 @@ salt_minion_cert_{{ cert_name }}_dirs:
     - watch:
       - x509: {{ cert_file }}
 
-{%- for ca_path,ca_cert in salt['mine.get'](cert.host, 'x509.get_pem_entries')[cert.host].iteritems() %}
+{%- for ca_path,ca_cert in salt['mine.get'](cert.host, 'x509.get_pem_entries').get(cert.host, {}).iteritems() %}
 
 {%- if '/etc/pki/ca/'+cert.authority in ca_path %}
 


### PR DESCRIPTION
It was responsible for

```
[CRITICAL] Rendering SLS 'base:salt.minion.cert' failed: Jinja variable 'dict object' has no attribute 'cfg01.mk20-lab-advanced.local'
[ERROR   ] Data passed to highstate outputter is not a valid highstate return: {'local': ["Rendering SLS 'base:salt.minion.cert' failed: Jinja variable 'dict object' has no attribute 'cfg01.mk20-lab-advanced.local'"]}
```
