### PR TITLE
Support letsencrypt certs for API.

### DIFF
--- a/salt/files/_api.conf
+++ b/salt/files/_api.conf
@@ -5,7 +5,10 @@ rest_cherrypy:
   port: {{ api.bind.port }}
   host: {{ api.bind.address }}
   {%- if api.get('ssl', {}).get('enabled', False) %}
-  {%- if api.ssl.engine == 'salt' %}
+  {%- if api.ssl.engine == 'letsencrypt' %}
+  ssl_crt: /etc/letsencrypt/live/{{ api.ssl.name }}/cert.pem
+  ssl_key: /etc/letsencrypt/live/{{ api.ssl.name }}/privkey.pem
+  {%- elif api.ssl.engine == 'salt' %}
   ssl_crt: /etc/ssl/certs/{{ system.name }}.{{ system.domain }}.crt
   ssl_key: /etc/ssl/private/{{ system.name }}.{{ system.domain }}.key
   {%- else %}


### PR DESCRIPTION
Letsencrypt could makes symlinks to standard locations in the future.