### PR TITLE
send mine always (not only on change)

### DIFF
--- a/salt/minion/ca.sls
+++ b/salt/minion/ca.sls
@@ -61,7 +61,7 @@ salt_system_ca_mine_send_ca_{{ ca_name }}:
   - func: x509.get_pem_entries
   - kwargs:
       glob_path: /etc/pki/ca/{{ ca_name }}/ca.crt
-  - onchanges:
+  - require:
     - x509: /etc/pki/ca/{{ ca_name }}/ca.crt
 
 {%- endfor %}


### PR DESCRIPTION
First run is made during salt-master cloud-init and thus `onchanges`
is not suitable here because ca.crt file is already generated.

cc @fpytloun @mceloud 