### PR TITLE
add travis and test kitchen [WIP]

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,142 @@
+---
+driver:
+  name: docker
+  hostname: salt.ci.local
+  use_sudo: false
+
+provisioner:
+  name: salt_solo
+  salt_install: bootstrap
+  salt_bootstrap_url: https://bootstrap.saltstack.com
+  salt_version: latest
+  require_chef: false
+  log_level: error
+  formula: salt
+  grains:
+    noservices: True
+  state_top:
+    base:
+      "*":
+        - salt
+  pillars:
+    top.sls:
+      base:
+        "*":
+          - salt
+          - common
+    common.sls:
+      salt:
+        minion:
+          enabled: true
+          master:
+            host: localhost
+      linux:
+        system:
+          enabled: true
+          name: salt
+          domain: ci.local
+  dependencies:
+    - name: git
+      repo: git
+      source: https://github.com/salt-formulas/salt-formula-git.git
+    - name: reclass
+      repo: git
+      source: https://github.com/salt-formulas/salt-formula-reclass.git
+
+verifier:
+  name: inspec
+  sudo: true
+
+platforms:
+  - name: ubuntu-trusty
+    driver_config:
+      image: trevorj/salty-whales:trusty
+      platform: ubuntu
+
+  - name: ubuntu-xenial
+    driver_config:
+      image: trevorj/salty-whales:xenial
+      platform: ubuntu
+
+suites:
+
+  - name: minion-default
+    provisioner:
+      pillars:
+        top.sls:
+          base:
+            "*":
+              - common
+              - minion_pki
+              - minion_mine
+              - minion_graph
+              - minion_handler
+      pillars-from-files:
+        minion_pki.sls: tests/pillar/minion_pki_ca.sls
+        minion_mine.sls: tests/pillar/minion_mine.sls
+        minion_graph.sls: tests/pillar/minion_graph.sls
+        minion_handler.sls: tests/pillar/minion_custom_handler.sls
+
+  - name: master-default
+    provisioner:
+      pillars:
+        top.sls:
+          base:
+            "*":
+              - common
+              - master_api
+              - master_acl
+              - master_ssh_key
+              - master_ssh_password
+              - master_ssh_root
+              - master_handler
+      pillars-from-files:
+        master_api.sls: tests/pillar/master_acl.sls
+        master_acl.sls: tests/pillar/master_api.sls
+        master_ssh_key.sls: tests/pillar/master_ssh_minion_key.sls
+        master_ssh_password.sls: tests/pillar/master_ssh_minion_password.sls
+        master_ssh_root.sls: tests/pillar/master_ssh_minion_root.sls
+        master_handler.sls: tests/pillar/master_custom_handler.sls
+
+  - name: control_cloud_digitalocean
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/control_cloud_digitalocean.sls
+
+  - name: control_cloud_openstack
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/control_cloud_openstack.sls
+
+  - name: control_virt
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/control_virt.sls
+
+  - name: master_single_pillar
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/master_single_pillar.sls
+
+  - name: master_single_reclass
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/master_single_reclass.sls
+
+  - name: minion_local_pillar
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/minion_local_pillar.sls
+
+  - name: minion_local_reclass
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/minion_local_reclass.sls
+
+  - name: minion_multi_master_failover
+    provisioner:
+      pillars-from-files:
+        salt.sls: tests/pillar/minion_multi_master_failover.sls
+
+
+  # vim: ft=yaml sw=2 ts=2 sts=2 tw=125

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+services:
+  - docker
+
+install:
+  - pip install PyYAML
+  - pip install virtualenv
+  - |
+    test -e Gemfile || cat <<EOF > Gemfile
+    source 'https://rubygems.org'
+    gem 'rake'
+    gem 'test-kitchen'
+    gem 'kitchen-docker'
+    gem 'kitchen-inspec'
+    gem 'inspec'
+    gem 'kitchen-salt', :git => 'https://github.com/epcim/kitchen-salt.git', :branch => 'dependencis-pkg-repo2'
+    #Waiting for PR#78
+    #gem 'kitchen-salt', '>=0.2.25'
+  - bundle install
+
+before_script:
+  - make test
+
+script:
+  - test ! -e .kitchen.yml || bundle exec kitchen test

--- a/tests/pillar/master_api.sls
+++ b/tests/pillar/master_api.sls
@@ -7,6 +7,8 @@ linux:
 salt:
   master:
     enabled: true
+    worker_threads: 2
+    command_timeout: 5
     source:
       engine: pkg
     pillar:


### PR DESCRIPTION
Done:
- fix pillars to pass running states
- merge core test suites "master/minion-default"

TODO:
- continue to lower the number of suites
- how to properly test for salt.control (dry mode)
- to test reclass will have to instantiate separate salt-master (possibly in non default location/ports...)

BTW:
These don't have default's in map.jinja but are required most of the time.
+    worker_threads: 2
+    command_timeout: 5

FYI @Martin890