### PR TITLE
add minion.conf default output/log level settings

### DIFF
--- a/salt/files/minion.conf
+++ b/salt/files/minion.conf
@@ -57,7 +57,8 @@ mine_interval: {{ minion.mine.get('interval', 30) }}
 
 {%- endif %}
 
-log_level: {{ minion.log.level }}
+log_level: {{ minion.log.get('level', 'error') }}
+state_output: {{ minion.log.get('state_output', 'changes') }}
 
 {%- if minion.proxy is defined %}
 proxy_host: {{ minion.proxy.host }}


### PR DESCRIPTION
add default convenient output from salt-call run.