### PR TITLE
retry_dns 0 for failover setup

### DIFF
--- a/salt/files/minion.conf
+++ b/salt/files/minion.conf
@@ -10,6 +10,7 @@ master:
 
 {%- if minion.get('master_type', 'default') == "failover" %}
 master_type: failover
+retry_dns: 0
 master_shuffle: True
 master_alive_interval: 60
 {%- endif %}


### PR DESCRIPTION
address fix for this issue: https://mirantis.jira.com/browse/RIL-973
```
root@sql-01:/home/ozhurba# salt-call mysql.status | grep -A1 wsrep_cluster_size | tail -n1
[INFO    ] Got list of available master addresses: ['192.168.10.111', '192.168.12.111']
[CRITICAL] 'master_type' set to 'failover' but 'retry_dns' is not 0. Setting 'retry_dns' to 0 to failover to the next master on DNS errors.
        3


```