### PR TITLE
Remove implicit ca_file symlink to ca-certificates

### DIFF
--- a/salt/minion/cert.sls
+++ b/salt/minion/cert.sls
@@ -115,13 +115,6 @@ salt_minion_cert_{{ cert_name }}_dirs:
     - watch:
       - x509: {{ ca_file }}
 
-{{ ca_file }}_local_trusted_symlink:
-  file.symlink:
-    - name: "{{ cacerts_dir }}/ca-{{ cert.authority }}.crt"
-    - target: {{ ca_file }}
-    - watch_in:
-      - cmd: salt_update_certificates
-
 {%- endif %}
 
 {%- endfor %}


### PR DESCRIPTION
tl;dr - it might be acheaved by 1) linux.system.certificates or 2) trusted_ca_minions (on line 189). 

As of now on hosts that has cert assigned it leads to state where symlink created is later replaced by file (which is the default for all other hosts when trusted_ca_minion is configured)