### PR TITLE
libvirt xml: pass loader, virt machine, cpu mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -481,6 +481,13 @@ Control VM provisioning:
                   rate:
                     period: '1800'
                     bytes: '1500'
+                # Custom per-node loader definition (e.g. for AArch64 UEFI)
+                loader:
+                  readonly: yes
+                  type: pflash
+                  path: /usr/share/AAVMF/AAVMF_CODE.fd
+                machine: virt-2.11  # Custom per-node virt machine type
+                cpu_mode: host-passthrough
                 mac:
                   nic01: AC:DE:48:AA:AA:AA
                   nic02: AC:DE:48:AA:AA:BB

--- a/salt/control/virt.sls
+++ b/salt/control/virt.sls
@@ -61,6 +61,15 @@ salt_control_virt_{{ cluster_name }}_{{ node_name }}:
   {%- elif rng is defined %}
   - rng: {{ rng }}
   {%- endif %}
+  {%- if  node.loader is defined %}
+  - loader: {{  node.loader }}
+  {%- endif %}
+  {%- if  node.machine is defined %}
+  - machine: {{ node.machine }}
+  {%- endif %}
+  {%- if  node.cpu_mode is defined %}
+  - cpu_mode: {{ node.cpu_mode }}
+  {%- endif %}
   - kwargs:
       {%- if cloud_init is defined %}
       cloud_init: {{ cloud_init }}

--- a/tests/pillar/control_virt_custom.sls
+++ b/tests/pillar/control_virt_custom.sls
@@ -96,11 +96,17 @@ salt:
             image: ubuntu.qcow
             size: medium
             img_dest: /var/lib/libvirt/ssdimages
+            machine: virt-2.11
+            cpu_mode: host-passthrough
           ubuntu2:
             provider: node02.domain.com
             image: bubuntu.qcomw
             size: small
             img_dest: /var/lib/libvirt/hddimages
+            loader:
+              readonly: yes
+              type: pflash
+              path: /usr/share/AAVMF/AAVMF_CODE.fd
           ubuntu3:
             provider: node03.domain.com
             image: meowbuntu.qcom2


### PR DESCRIPTION
Spawning AArch64 VMs using salt.control.virt requires a few extra
domain configuration items to be configurable:
- libvirt xml: pass loader param to vm
  Based on upstream commit [1].
- libvirt xml: pass virt machine type
- libvirt xml: pass cpu mode to vm
- virt module: Allow NVRAM unlinking on DOM undefine
  UEFI-enabled VMs usually have pflash (NVRAM) devices attached,
  which require one additional libvirt flag to be passed at 'undefine'.
  This is usually the case for AArch64 (arm64) VMs, where AAVMF (AA64
  UEFI) is the only supported guest bootloader.

[1] https://github.com/saltstack/salt/commit/9cace9adb