### PR TITLE
minion.conf: Accept tcp_keepalive* properties

### DIFF
--- a/salt/files/minion.conf
+++ b/salt/files/minion.conf
@@ -26,7 +26,11 @@ id: {{ minion.id | default(system.name~"."~system.domain) }}
   'max_event_size',
   'random_reauth_delay',
   'recon_default',
-  'recon_max'
+  'recon_max',
+  'tcp_keepalive',
+  'tcp_keepalive_cnt',
+  'tcp_keepalive_idle',
+  'tcp_keepalive_intvl'
 ] %}
 {%- for opt in opt_list %}
 {%- if minion.get(opt) %}


### PR DESCRIPTION
Add TCP keepalive configuration options [1] to the list of accepted
minion config keys.

This should be useful when trying to tune keepalive to work around issues like [2].

[1] https://docs.saltstack.com/en/latest/ref/configuration/minion.html
[2] https://github.com/saltstack/salt/issues/38157